### PR TITLE
Remove dependency on retired zlibbioc

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,7 @@ Version: 1.41.2
 Author: Kevin Horan, Thomas Girke
 Maintainer: Thomas Girke <thomas.girke@ucr.edu>
 Suggests: ChemmineR, BiocStyle, knitr,  knitrBootstrap, BiocManager, rmarkdown,RUnit
-Imports: BiocGenerics, zlibbioc, Rcpp (>= 0.11.0)
+Imports: BiocGenerics, Rcpp (>= 0.11.0)
 Description: ChemmineOB provides an R interface to a subset of cheminformatics functionalities implemented by the OpelBabel C++ project. OpenBabel is an open source cheminformatics toolbox that includes utilities for structure format interconversions, descriptor calculations, compound similarity searching and more. ChemineOB aims to make a subset of these utilities available from within R. For non-developers, ChemineOB is primarily intended to be used from ChemmineR as an add-on package rather than used directly.
 License: Artistic-2.0
 Depends: R (>= 2.15.1), methods
@@ -17,4 +17,4 @@ biocViews: Cheminformatics, BiomedicalInformatics, Pharmacogenetics,
         Pharmacogenomics, MicrotitrePlateAssay, CellBasedAssays, Visualization,
         Infrastructure, DataImport, Clustering, Proteomics, Metabolomics
 VignetteBuilder: knitr
-LinkingTo: BH, Rcpp, zlibbioc
+LinkingTo: BH, Rcpp

--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -7,4 +7,4 @@
 #endif 
 
 PKG_CPPFLAGS = -I/usr/include/openbabel3  -I/usr/include/eigen3  -DUSE_BOOST -DHAVE_EIGEN  -I/usr/local/include/eigen3 -I/usr/local/include/openbabel3  @OPENBABEL_CFLAGS@ 
-PKG_LIBS =  -L/usr/local/lib/openbabel3  @OPENBABEL_LIBS@
+PKG_LIBS =  -L/usr/local/lib/openbabel3  @OPENBABEL_LIBS@ -lz

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -3,4 +3,4 @@ PKG_LIBS += -L${OPEN_BABEL_BIN}${R_ARCH}/bin -lopenbabel
 
 PKG_CXXFLAGS +=  -IC:/openbabel3/deps/eigen-3.4.0  -DHAVE_EIGEN -DHAVE_ISFINITE
 PKG_CXXFLAGS += -Wno-misleading-indentation -fPIC
-PKG_LIBS += $(shell echo 'zlibbioc::pkgconfig("PKG_LIBS_shared")' | "${R_HOME}/bin/R" --vanilla --slave)
+PKG_LIBS += -lz


### PR DESCRIPTION
The `zlibbioc` has been removed from bioconductor. You are supposed to use the system zlib now via `-lz`.